### PR TITLE
Resolve game crash on screen change

### DIFF
--- a/src/main/java/xyz/nebulaquest/screen/ScreenManager.java
+++ b/src/main/java/xyz/nebulaquest/screen/ScreenManager.java
@@ -1,6 +1,7 @@
 package xyz.nebulaquest.screen;
 
 import java.util.HashMap;
+import java.util.Optional;
 
 import xyz.nebulaquest.event.Event;
 import xyz.nebulaquest.event.EventGetter;
@@ -10,12 +11,14 @@ import xyz.nebulaquest.renderer.Renderer;
 public class ScreenManager {
   public HashMap<String, Screen> screens;
   private String selected;
+  private Optional<String> nextScreen;
   private Event closeGameEvent;
 
   public ScreenManager(InputManager inputManager) {
     this.screens = new HashMap<>();
     this.closeGameEvent = new Event();
     this.selected = "menu";
+    this.nextScreen = Optional.empty();
 
     registerScreen("menu", new MenuScreen(inputManager, this));
     registerScreen("credits", new CreditsScreen(inputManager, this));
@@ -39,9 +42,7 @@ public class ScreenManager {
       return;
     }
 
-    getCurrent().unload();
-    selected = state;
-    getCurrent().load();
+    nextScreen = Optional.of(state);
   }
 
   private boolean isScreenRestated(String key) {
@@ -53,7 +54,18 @@ public class ScreenManager {
   }
 
   public void update(long deltaTime) {
+    loadNextScreen();    
     getCurrent().update(deltaTime);
+  }
+
+  private void loadNextScreen() {
+    if (!nextScreen.isPresent()) {
+      return;
+    }
+    
+    getCurrent().unload();
+    selected = nextScreen.get();
+    getCurrent().load();
   }
 
   public void draw(Renderer renderer) {


### PR DESCRIPTION
Address the issue where switching from one screen to another using ScreenManager.change() during the execution of update or draw methods would lead to a render system crash and consequently a game crash.

Previously, the implementation of ScreenManager.change() immediately change selected screen, causing errors. The fix involves modifying the ScreenManager.change() implementation to delay the screen change until the next frame. This ensures that the draw and update processes for the current screen complete before the switch occurs.